### PR TITLE
Add append/prepend/replaceBufferBytes hostcalls.

### DIFF
--- a/example/example.zig
+++ b/example/example.zig
@@ -708,7 +708,7 @@ const HttpBodyOperation = struct {
         if (std.mem.indexOf(u8, self.request_path.raw_data, "echo")) |_| {
             return enums.Action.Continue;
         } else if (std.mem.indexOf(u8, self.request_path.raw_data, "sha256-response")) |_| {
-            // Increment total_request_body_size to have the entire body size.
+            // Increment total_response_body_size to have the entire body size.
             self.total_response_body_size += body_size;
 
             // Wait until we see the entire body.
@@ -725,14 +725,14 @@ const HttpBodyOperation = struct {
             // Log the calculated sha256 of response body.
             const message = std.fmt.allocPrint(
                 allocator,
-                "response body sha256: {x}",
-                .{checksum},
+                "response body sha256 (original size={d}) : {x}",
+                .{ self.total_response_body_size, checksum },
             ) catch unreachable;
             defer allocator.free(message);
             hostcalls.log(enums.LogLevel.Info, message) catch unreachable;
 
             // Set the calculated sha256 to the response body.
-            hostcalls.setBufferBytes(enums.BufferType.HttpResponseBody, 0, self.total_request_body_size, message) catch unreachable;
+            hostcalls.replaceBufferBytes(enums.BufferType.HttpResponseBody, message) catch unreachable;
         }
         return enums.Action.Continue;
     }

--- a/lib/hostcalls.zig
+++ b/lib/hostcalls.zig
@@ -50,13 +50,25 @@ extern "env" fn proxy_set_buffer_bytes(
     data_size: usize,
 ) enums.Status;
 
-pub fn setBufferBytes(buffer_type: enums.BufferType, start: usize, max_size: usize, data: []const u8) hostcallErrors!void {
+fn setBufferBytes(buffer_type: enums.BufferType, start: usize, max_size: usize, data: []const u8) hostcallErrors!void {
     switch (proxy_set_buffer_bytes(buffer_type, start, max_size, data.ptr, data.len)) {
         .Ok => {},
         .BadArgument => return hostcallErrors.BadArgument,
         .InvalidMemoryAccess => return hostcallErrors.InvalidMemoryAccess,
         else => unreachable,
     }
+}
+
+pub fn appendBufferBytes(buffer_type: enums.BufferType, data: []const u8) hostcallErrors!void {
+    try setBufferBytes(buffer_type, std.math.maxInt(usize), 0, data);
+}
+
+pub fn prependBufferBytes(buffer_type: enums.BufferType, data: []const u8) hostcallErrors!void {
+    try setBufferBytes(buffer_type, 0, 0, data);
+}
+
+pub fn replaceBufferBytes(buffer_type: enums.BufferType, data: []const u8) hostcallErrors!void {
+    try setBufferBytes(buffer_type, 0, std.math.maxInt(usize), data);
 }
 
 pub const WasmData = struct {


### PR DESCRIPTION
Followed the style of Go SDK: https://github.com/tetratelabs/proxy-wasm-go-sdk/pull/174

Signed-off-by: Takeshi Yoneda <takeshi@tetrate.io>