### PR TITLE
Fix Wasm build path.

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -11,7 +11,7 @@ pub fn build(b: *Builder) void {
     };
 
     for (examples) |example| {
-        const lib = b.addStaticLibrary(example[0], example[1]);
+        const lib = b.addSharedLibrary(example[0], example[1], b.version(1,0,0));
         lib.setBuildMode(mode);
         lib.setTarget(.{ .cpu_arch = .wasm32, .os_tag = .wasi });
         lib.install();

--- a/example/envoy.yaml
+++ b/example/envoy.yaml
@@ -18,7 +18,7 @@ bootstrap_extensions:
         runtime: "envoy.wasm.runtime.v8"
         code:
           local:
-            filename: "zig-cache/lib/example.wasm"
+            filename: "zig-out/lib/example.wasm"
 
 static_resources:
   listeners:
@@ -64,7 +64,7 @@ static_resources:
                           runtime: "envoy.wasm.runtime.v8"
                           code:
                             local:
-                              filename: "zig-cache/lib/example.wasm"
+                              filename: "zig-out/lib/example.wasm"
                   - name: envoy.filters.http.router
                     typed_config: {}
 
@@ -110,7 +110,7 @@ static_resources:
                           runtime: "envoy.wasm.runtime.v8"
                           code:
                             local:
-                              filename: "zig-cache/lib/example.wasm"
+                              filename: "zig-out/lib/example.wasm"
                   - name: envoy.filters.http.router
                     typed_config: {}
 
@@ -156,7 +156,7 @@ static_resources:
                           runtime: "envoy.wasm.runtime.v8"
                           code:
                             local:
-                              filename: "zig-cache/lib/example.wasm"
+                              filename: "zig-out/lib/example.wasm"
                   - name: envoy.filters.http.router
                     typed_config: {}
 
@@ -185,7 +185,7 @@ static_resources:
                     runtime: "envoy.wasm.runtime.v8"
                     code:
                       local:
-                        filename: "zig-cache/lib/example.wasm"
+                        filename: "zig-out/lib/example.wasm"
 
             - name: envoy.tcp_proxy
               typed_config:


### PR DESCRIPTION
Night Zig has the different output for staticlib and outputs the archive file which contains the Wasm binary (prefixed `.o`). So we switched to use sharedLibrary to produce bare Wasm binaries under zig-out.

Signed-off-by: Takeshi Yoneda <takeshi@tetrate.io>